### PR TITLE
Replace deprecated load method

### DIFF
--- a/jinja_cli/__main__.py
+++ b/jinja_cli/__main__.py
@@ -94,7 +94,7 @@ def load_data_yaml(fin):
     :   data;
     '''
 
-    return yaml.load(fin)
+    return yaml.safe_load(fin)
 
 def load_data(fname, fmt, defines):
 


### PR DESCRIPTION
LoadWarning: calling yaml.load() without Loader=... is deprecated, as…the default Loader is unsafe. Please read [https://msg.pyyaml.org/load](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) for full details