### PR TITLE
Option to fail on undefined variables

### DIFF
--- a/jinja_cli/__main__.py
+++ b/jinja_cli/__main__.py
@@ -8,6 +8,7 @@ from jinja2 import DictLoader
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 from jinja2 import Template
+from jinja2 import StrictUndefined, Undefined
 from os.path import basename
 from os.path import dirname
 import argparse
@@ -217,6 +218,16 @@ def parse_args():
 
     ##  add arg;
     parser.add_argument(
+        '--strict-undefined',
+        action='store_const',
+        const=StrictUndefined,
+        dest='undefined_type',
+        default=Undefined,
+        help='Fail on undefined variables',
+    )
+
+    ##  add arg;
+    parser.add_argument(
         'template',
         nargs='?',
         type=str,
@@ -243,12 +254,14 @@ def main():
         env = Environment(
             loader=DictLoader({ '-': sys.stdin.read() }),
             keep_trailing_newline=True,
+            undefined=args.undefined_type,
         )
         template = env.get_template('-')
     else:
         env = Environment(
             loader=FileSystemLoader(dirname(args.template)),
             keep_trailing_newline=True,
+            undefined=args.undefined_type,
         )
         template = env.get_template(basename(args.template))
 


### PR DESCRIPTION
When using Jinja on config files, the absence of expansion can be quite serious. This PR introduces an option to fail when Jinja encounters a variable that is not set. SOmething like this:
```
$ echo '{{ somevar }}' > template.j2
echo '{}' | jinja -f json -d - ./template.j2

echo '{}' | jinja -f json -d - --strict-undefined ./template.j2
Traceback (most recent call last):
  File "jinja_cli/__main__.py", line 285, in <module>
    main()
  File "jinja_cli/__main__.py", line 272, in main
    rendered = template.render(data)
  File "/home/quest/tmp/python/lib/python3.7/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/home/quest/tmp/python/lib/python3.7/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/home/quest/tmp/python/lib/python3.7/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "./template.j2", line 1, in top-level template code
    {{ somevar }}
jinja2.exceptions.UndefinedError: 'somevar' is undefined
```
I decided not to catch the exception since it helpfully contains the actual template expression that causes the issue. Ideally, we would trim the stack trace, but that seems excessive?